### PR TITLE
Added maxSize to asset form field

### DIFF
--- a/src/ride/web/base/controller/AssetController.php
+++ b/src/ride/web/base/controller/AssetController.php
@@ -649,6 +649,7 @@ class AssetController extends AbstractController {
             'dimension' => $assetModel->getDimension($asset),
             'locales' => $i18n->getLocaleCodeList(),
             'locale' => $locale,
+            'maxSize' => $this->config->get('asset.upload.size.max')
         ));
 
         $form->processView($view);


### PR DESCRIPTION
Using the `asset.upload.size.max` parameter, we add a maxSize variable that can be used in the Asset form template to do validation on the the file's size.
